### PR TITLE
Support Autolayout on Storyboard

### DIFF
--- a/AwesomeMenu/AwesomeMenu/AwesomeMenu.h
+++ b/AwesomeMenu/AwesomeMenu/AwesomeMenu.h
@@ -36,6 +36,8 @@
 @property (nonatomic, assign) BOOL    rotateAddButton;
 
 - (id)initWithFrame:(CGRect)frame startItem:(AwesomeMenuItem*)startItem optionMenus:(NSArray *)aMenusArray;
+- (void)setStartButton:(AwesomeMenuItem *)startItem;
+- (void)setMenusArray:(NSArray *)aMenusArray;
 
 @end
 

--- a/AwesomeMenu/AwesomeMenu/AwesomeMenu.m
+++ b/AwesomeMenu/AwesomeMenu/AwesomeMenu.m
@@ -54,9 +54,38 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
 @synthesize menusArray = _menusArray;
 
 #pragma mark - Initialization & Cleaning up
+
+// for autolayout
+- (id) initWithCoder:(NSCoder*)aDecoder{
+
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+		self.startPoint = CGPointMake(self.bounds.origin.x + (self.bounds.size.width / 2), self.bounds.origin.y + (self.bounds.size.height / 2));
+    }
+    return self;
+}
+
+- (void)setFrame:(CGRect)frame{
+    [super setFrame:frame];
+}
+
+- (void)awakeFromNib{
+}
+
 - (id)initWithFrame:(CGRect)frame startItem:(AwesomeMenuItem*)startItem optionMenus:(NSArray *)aMenusArray
 {
     self = [super initWithFrame:frame];
+    if (self) {
+        [self commonInit];
+        [self setStartButton:startItem];
+        [self setMenusArray:aMenusArray];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
     if (self) {
         self.backgroundColor = [UIColor clearColor];
 		
@@ -71,16 +100,7 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
         self.closeRotation = kAwesomeMenuDefaultCloseRotation;
         self.animationDuration = kAwesomeMenuDefaultAnimationDuration;
         self.rotateAddButton = YES;
-        
-        self.menusArray = aMenusArray;
-        
-        // assign startItem to "Add" Button.
-        _startButton = startItem;
-        _startButton.delegate = self;
-        _startButton.center = self.startPoint;
-        [self addSubview:_startButton];
     }
-    return self;
 }
 
 
@@ -201,6 +221,15 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
 }
 
 #pragma mark - Instant methods
+- (void)setStartButton:(AwesomeMenuItem *)startItem
+{
+    // assign startItem to "Add" Button.
+    _startButton = startItem;
+    _startButton.delegate = self;
+    _startButton.center = self.startPoint;
+    [self addSubview:_startButton];
+}
+
 - (void)setMenusArray:(NSArray *)aMenusArray
 {	
     if (aMenusArray == _menusArray)


### PR DESCRIPTION
Support Autolayout on Storyboard. Now it's support initWithCoder() and we can use IBOutlet like follow:

foo.h

    @property (weak, nonatomic) IBOutlet AwesomeMenu *awesomeMenu;

To use this, insert an UIView object on Storyboard and change [custom class] class field from [UIView] to [AwesomeMenu].
Then you must link from Referencing Outlets to IBOutlet.
It can be controlled under Autolayout rules, you may add constraint(s) to this custom component on Storyboard.

foo.m

    @synthesize awesomeMenu;
     
    AwesomeMenuItem *menuItem1 = [[AwesomeMenuItem alloc] initWithImage:
    ...
                                                    highlightedContentImage:nil];
    ...
    NSArray *menus = [NSArray arrayWithObjects:menuItem1, menuItem2, menuItem3, menuItem4, nil];

    AwesomeMenuItem *startItem = [[AwesomeMenuItem alloc] initWithImage:
    ....
                                                highlightedContentImage:[UIImage imageNamed:@"icon-plus-highlighted.png"]];
    [awesomeMenu setStartButton:startItem];
    [awesomeMenu setMenusArray:menus];

We can't call initWithFrame() in Storyboard layout style, I make setStartButton() and setMenusArray() to set start button and menus easily.